### PR TITLE
Autocomplete should not open when focusing field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
 [#187](https://github.com/corejavascript/typeahead.js/pull/187)
 * Don't fire unnecessary autocomplete requests after an autocomplete finishes.
 [lawgical/servemanager#2327](https://github.com/lawgical/servemanager/pull/2327)
+* Don't auto-open the autocompleter when focusing a field. Only when actually
+changing it's value. (Fixes behavior change between twitter typeahead and
+corejavascript/typeahead).
 
 
 ### 1.2.0 September 25, 2017

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -59,7 +59,7 @@ var Typeahead = (function() {
     .onSync('datasetCleared', this._onDatasetCleared, this);
 
     // composed event handlers for input
-    onFocused = c(this, 'activate', 'open', '_onFocused');
+    onFocused = c(this, 'activate');
     onBlurred = c(this, 'deactivate', '_onBlurred');
     onEnterKeyed = c(this, 'isActive', 'isOpen', '_onEnterKeyed');
     onTabKeyed = c(this, 'isActive', 'isOpen', '_onTabKeyed');

--- a/test/typeahead/typeahead_spec.js
+++ b/test/typeahead/typeahead_spec.js
@@ -207,9 +207,9 @@ describe('Typeahead', function() {
         expect(this.view.isActive()).toBe(true);
       });
 
-      it('should open menu', function() {
+      it('should NOT open menu', function() {
         this.input.trigger(eventName);
-        expect(this.menu.open).toHaveBeenCalled();
+        expect(this.menu.open).not.toHaveBeenCalled();
       });
     });
 
@@ -218,15 +218,15 @@ describe('Typeahead', function() {
         this.view.activate();
       });
 
-      it('should open menu', function() {
+      it('should NOT open menu', function() {
         this.input.trigger(eventName);
-        expect(this.menu.open).toHaveBeenCalled();
+        expect(this.menu.open).not.toHaveBeenCalled();
       });
 
-      it('should update menu for query if minLength met', function() {
+      it('should NOT update menu for query if minLength met', function() {
         this.input.getQuery.andReturn('bar');
         this.input.trigger(eventName);
-        expect(this.menu.update).toHaveBeenCalledWith('bar');
+        expect(this.menu.update).not.toHaveBeenCalled();
       });
 
       it('should not update menu for query if minLength not met', function() {


### PR DESCRIPTION
In twitter-typeahead, the autocomplete menu only opens after typing in a field, not after focusing it. This makes new typeahead behave the same, and removes some extra unnecessary remote requests when just tabbing through unedited values (like addresses).